### PR TITLE
https:// should be removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ works in cases where the IP mapping exists in the hostsfile.
 
 ## Get it
 
-    go get -u https://github.com/jaytaylor/go-hostsfile
+    go get -u github.com/jaytaylor/go-hostsfile
 
 ## Usage
 


### PR DESCRIPTION
`$ go get -u https://github.com/jaytaylor/go-hostsfile
package https:/github.com/jaytaylor/go-hostsfile: https:/github.com/jaytaylor/go-hostsfile: invalid import path: malformed import path "https:/github.com/jaytaylor/go-hostsfile": invalid char ':'
`