### PR TITLE
Use UNIX path on all OSs other than Windows and Plan9

### DIFF
--- a/hosts_path_unix.go
+++ b/hosts_path_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build !plan9 !windows
 
 package hostsfile
 


### PR DESCRIPTION
Previous settings will cause this library fail to build in other OSs including many BSD distributions (FreeBSD, OpenBSD, NetBSD, etc). I found this problem while trying to build it on my FreeBSD server.

Since /etc/hosts is a pretty standard path for finding hosts file, it should be safe enough to set /etc/hosts as the default path.