### PR TITLE
Support Go 1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 language: go
 go:
   - tip
-  - 1.8
-  - 1.7
-  - 1.6
-  - 1.5
-  - 1.4
-  - 1.3
-  - 1.2
+  - 1.18
+  - 1.17
 notifications:
   email:
     on_success: change

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jaytaylor/go-hostsfile
+
+go 1.18

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -1,13 +1,11 @@
-package hostsfile_test
+package hostsfile
 
 import (
 	"testing"
-
-	h "../go-hostsfile"
 )
 
 func TestHostsReverseLookup(t *testing.T) {
-	res, err := h.ReverseLookup("127.0.0.1")
+	res, err := ReverseLookup("127.0.0.1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +104,7 @@ fe80::1%lo0	localhost
 	}
 
 	for i, testCase := range testCases {
-		res, err := h.ParseHosts([]byte(testCase.hostsFileContent), nil)
+		res, err := ParseHosts([]byte(testCase.hostsFileContent), nil)
 		if err != nil {
 			t.Fatalf("[i=%v] Error parsing hosts content: %s", i, err)
 		}


### PR DESCRIPTION
Fix:
- containerd/nerdctl#900

```
$ cd nerdctl
$ go mod tidy
github.com/containerd/nerdctl/pkg/dnsutil/hostsstore imports
        github.com/jaytaylor/go-hostsfile tested by
        github.com/jaytaylor/go-hostsfile.test imports
        ../go-hostsfile: "../go-hostsfile" is relative, but relative import paths are not supported in module mode
```
